### PR TITLE
Closes #2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -54,7 +54,7 @@ hasChildren = true
 
 ############################# Default parameters ##########################
 [params]
-logo = "static/images/rit.png"
+logo = "images/rit.png"
 
 # customize color
 primary_color = "#F76902"


### PR DESCRIPTION
This changes the path for the site logo from `static/images/rit.png` to `images/rit.png` due to how the Hugo content management system links to static files at the root of the site path.